### PR TITLE
feat(phase2): AI Chat Infrastructure & Web Scraping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "omakase-ai",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.2",
         "@auth/prisma-adapter": "^2.11.1",
         "@prisma/adapter-pg": "^7.1.0",
         "@prisma/client": "^7.1.0",
         "@types/pg": "^8.16.0",
+        "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.3",
@@ -47,6 +49,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
+      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@auth/core": {
@@ -280,6 +302,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2771,6 +2802,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2966,6 +3003,48 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chevrotain": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
@@ -3092,6 +3171,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3275,6 +3382,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -3335,6 +3497,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -3347,6 +3534,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4509,6 +4708,37 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
@@ -5092,6 +5322,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5828,6 +6071,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
@@ -6064,6 +6319,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -7294,6 +7598,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7499,6 +7809,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -7593,6 +7912,39 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -7751,7 +8103,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.2",
     "@auth/prisma-adapter": "^2.11.1",
     "@prisma/adapter-pg": "^7.1.0",
     "@prisma/client": "^7.1.0",
     "@types/pg": "^8.16.0",
+    "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const agent = await prisma.agent.findUnique({
+    where: { id, userId: session.user.id },
+    include: {
+      products: true,
+      knowledgeBase: true,
+      _count: {
+        select: { conversations: true },
+      },
+    },
+  });
+
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(agent);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { name, description, personality, widgetConfig, isActive } = body;
+
+    const agent = await prisma.agent.update({
+      where: { id, userId: session.user.id },
+      data: {
+        ...(name !== undefined && { name }),
+        ...(description !== undefined && { description }),
+        ...(personality !== undefined && { personality }),
+        ...(widgetConfig !== undefined && { widgetConfig }),
+        ...(isActive !== undefined && { isActive }),
+      },
+    });
+
+    return NextResponse.json(agent);
+  } catch (error) {
+    console.error("Failed to update agent:", error);
+    return NextResponse.json(
+      { error: "Failed to update agent" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await prisma.agent.delete({
+      where: { id, userId: session.user.id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete agent:", error);
+    return NextResponse.json(
+      { error: "Failed to delete agent" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchPage, extractProducts } from "@/lib/scraper";
+import { getDefaultPersonality } from "@/lib/prompt-generator";
+
+export async function GET() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const agents = await prisma.agent.findMany({
+    where: { userId: session.user.id },
+    include: {
+      _count: {
+        select: { conversations: true, products: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(agents);
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { name, websiteUrl, description, personality } = body;
+
+    if (!name || !websiteUrl) {
+      return NextResponse.json(
+        { error: "Name and website URL are required" },
+        { status: 400 }
+      );
+    }
+
+    // Create agent
+    const agent = await prisma.agent.create({
+      data: {
+        name,
+        websiteUrl,
+        description,
+        personality: personality || getDefaultPersonality(),
+        userId: session.user.id,
+      },
+    });
+
+    // Start background scraping (in production, use a queue)
+    scrapeAndStoreProducts(agent.id, websiteUrl).catch(console.error);
+
+    return NextResponse.json(agent, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create agent:", error);
+    return NextResponse.json(
+      { error: "Failed to create agent" },
+      { status: 500 }
+    );
+  }
+}
+
+async function scrapeAndStoreProducts(agentId: string, websiteUrl: string) {
+  try {
+    // Fetch and parse the main page
+    const page = await fetchPage(websiteUrl);
+
+    // Store page content as knowledge base
+    await prisma.knowledgeBase.create({
+      data: {
+        agentId,
+        type: "URL",
+        title: page.title || websiteUrl,
+        content: `URL: ${page.url}\n\nタイトル: ${page.title}\n\n説明: ${page.description}\n\n内容:\n${page.content}`,
+        status: "READY",
+        metadata: page.metadata,
+      },
+    });
+
+    // Extract products using AI
+    const products = await extractProducts(page);
+
+    // Store products
+    for (const product of products) {
+      await prisma.product.create({
+        data: {
+          agentId,
+          name: product.name,
+          price: product.price,
+          currency: product.currency || "JPY",
+          description: product.description,
+          imageUrl: product.imageUrl,
+          category: product.category,
+          features: product.features || [],
+        },
+      });
+    }
+
+    console.log(
+      `Scraped ${products.length} products for agent ${agentId}`
+    );
+  } catch (error) {
+    console.error(`Failed to scrape products for agent ${agentId}:`, error);
+  }
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { chatStream, type ChatMessage } from "@/lib/claude";
+import {
+  generateSystemPrompt,
+  getDefaultPersonality,
+  type PersonalityConfig,
+} from "@/lib/prompt-generator";
+
+export const runtime = "nodejs";
+
+interface ChatRequestBody {
+  agentId: string;
+  message: string;
+  conversationId?: string;
+  sessionId?: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: ChatRequestBody = await request.json();
+    const { agentId, message, conversationId, sessionId } = body;
+
+    if (!agentId || !message) {
+      return new Response(
+        JSON.stringify({ error: "agentId and message are required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Fetch agent with related data
+    const agent = await prisma.agent.findUnique({
+      where: { id: agentId },
+      include: {
+        products: true,
+        knowledgeBase: {
+          where: { status: "READY" },
+        },
+      },
+    });
+
+    if (!agent) {
+      return new Response(JSON.stringify({ error: "Agent not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!agent.isActive) {
+      return new Response(JSON.stringify({ error: "Agent is not active" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Get or create conversation
+    let conversation;
+    const currentSessionId = sessionId || crypto.randomUUID();
+
+    if (conversationId) {
+      conversation = await prisma.conversation.findUnique({
+        where: { id: conversationId },
+        include: { messages: { orderBy: { createdAt: "asc" } } },
+      });
+    }
+
+    if (!conversation) {
+      conversation = await prisma.conversation.create({
+        data: {
+          agentId,
+          sessionId: currentSessionId,
+          status: "ACTIVE",
+        },
+        include: { messages: { orderBy: { createdAt: "asc" } } },
+      });
+    }
+
+    // Save user message
+    await prisma.message.create({
+      data: {
+        conversationId: conversation.id,
+        role: "USER",
+        content: message,
+      },
+    });
+
+    // Build chat history
+    const chatHistory: ChatMessage[] = conversation.messages.map((msg) => ({
+      role: msg.role === "USER" ? "user" : "assistant",
+      content: msg.content,
+    }));
+    chatHistory.push({ role: "user", content: message });
+
+    // Generate system prompt
+    const personality = (agent.personality as unknown as PersonalityConfig) || getDefaultPersonality();
+    const systemPrompt = generateSystemPrompt({
+      agent,
+      products: agent.products,
+      knowledgeBase: agent.knowledgeBase,
+      personality,
+    });
+
+    // Create streaming response
+    const encoder = new TextEncoder();
+    let fullResponse = "";
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          // Send conversation metadata first
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                type: "metadata",
+                conversationId: conversation.id,
+                sessionId: currentSessionId,
+              })}\n\n`
+            )
+          );
+
+          // Stream Claude response
+          for await (const chunk of chatStream(chatHistory, systemPrompt)) {
+            fullResponse += chunk;
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "message", content: chunk })}\n\n`
+              )
+            );
+          }
+
+          // Save assistant response
+          await prisma.message.create({
+            data: {
+              conversationId: conversation.id,
+              role: "ASSISTANT",
+              content: fullResponse,
+            },
+          });
+
+          // Send done event
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "done", fullContent: fullResponse })}\n\n`
+            )
+          );
+          controller.close();
+        } catch (error) {
+          console.error("Stream error:", error);
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                type: "error",
+                message: error instanceof Error ? error.message : "Unknown error",
+              })}\n\n`
+            )
+          );
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("Chat API error:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Internal server error",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -1,0 +1,121 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+// Types for chat messages
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ChatResponse {
+  content: string;
+  stopReason: string | null;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+// Claude client singleton
+const getClient = () => {
+  const apiKey = process.env.CLAUDE_API_KEY;
+  if (!apiKey) {
+    throw new Error("CLAUDE_API_KEY is not set");
+  }
+  return new Anthropic({ apiKey });
+};
+
+// Default model configuration
+const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Send a chat message to Claude and get a response
+ */
+export async function chat(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }
+): Promise<ChatResponse> {
+  const client = getClient();
+
+  const response = await client.messages.create({
+    model: options?.model || DEFAULT_MODEL,
+    max_tokens: options?.maxTokens || DEFAULT_MAX_TOKENS,
+    temperature: options?.temperature ?? 0.7,
+    system: systemPrompt,
+    messages: messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    })),
+  });
+
+  const textContent = response.content.find((block) => block.type === "text");
+
+  return {
+    content: textContent?.type === "text" ? textContent.text : "",
+    stopReason: response.stop_reason,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+  };
+}
+
+/**
+ * Stream chat response from Claude
+ */
+export async function* chatStream(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }
+): AsyncGenerator<string, void, unknown> {
+  const client = getClient();
+
+  const stream = await client.messages.stream({
+    model: options?.model || DEFAULT_MODEL,
+    max_tokens: options?.maxTokens || DEFAULT_MAX_TOKENS,
+    temperature: options?.temperature ?? 0.7,
+    system: systemPrompt,
+    messages: messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    })),
+  });
+
+  for await (const event of stream) {
+    if (
+      event.type === "content_block_delta" &&
+      event.delta.type === "text_delta"
+    ) {
+      yield event.delta.text;
+    }
+  }
+}
+
+/**
+ * Generate a single response (convenience method)
+ */
+export async function generateResponse(
+  prompt: string,
+  systemPrompt: string,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }
+): Promise<string> {
+  const response = await chat(
+    [{ role: "user", content: prompt }],
+    systemPrompt,
+    options
+  );
+  return response.content;
+}

--- a/src/lib/prompt-generator.ts
+++ b/src/lib/prompt-generator.ts
@@ -1,0 +1,146 @@
+import type { Agent, Product, KnowledgeBase } from "@prisma/client";
+
+export interface PersonalityConfig {
+  tone: "formal" | "friendly" | "professional" | "casual";
+  formalityLevel: number; // 1-10
+  emojiUsage: number; // 0-10
+  customInstructions?: string;
+  greetingMessage?: string;
+  farewellMessage?: string;
+}
+
+export interface PromptContext {
+  agent: Agent;
+  products: Product[];
+  knowledgeBase: KnowledgeBase[];
+  personality?: PersonalityConfig;
+}
+
+const TONE_INSTRUCTIONS: Record<string, string> = {
+  formal:
+    "丁寧語を使い、敬語を適切に使用してください。フォーマルで礼儀正しい対応をしてください。",
+  friendly:
+    "フレンドリーで親しみやすい口調で話してください。カジュアルな表現も適度に使ってください。",
+  professional:
+    "専門的で信頼感のある口調で話してください。製品知識を活かした的確なアドバイスを心がけてください。",
+  casual:
+    "カジュアルでリラックスした口調で話してください。お客様と友達のように会話してください。",
+};
+
+/**
+ * Generate system prompt for AI agent based on context
+ */
+export function generateSystemPrompt(context: PromptContext): string {
+  const { agent, products, knowledgeBase, personality } = context;
+
+  // Base instructions
+  let systemPrompt = `あなたは「${agent.name}」という名前のAI接客アシスタントです。
+
+## あなたの役割
+あなたはECサイトの接客AIエージェントとして、お客様の質問に答え、商品をおすすめし、購入をサポートします。
+
+## 担当サイト
+${agent.websiteUrl}
+${agent.description ? `\n説明: ${agent.description}` : ""}
+
+`;
+
+  // Personality instructions
+  if (personality) {
+    systemPrompt += `## 口調・性格
+${TONE_INSTRUCTIONS[personality.tone] || TONE_INSTRUCTIONS.friendly}
+`;
+
+    if (personality.formalityLevel > 7) {
+      systemPrompt += `非常に丁寧な言葉遣いを心がけてください。\n`;
+    } else if (personality.formalityLevel < 4) {
+      systemPrompt += `カジュアルな言葉遣いでOKです。\n`;
+    }
+
+    if (personality.emojiUsage > 5) {
+      systemPrompt += `適度に絵文字を使って、温かみのある対応をしてください。\n`;
+    } else if (personality.emojiUsage === 0) {
+      systemPrompt += `絵文字は使わないでください。\n`;
+    }
+
+    if (personality.customInstructions) {
+      systemPrompt += `\n特別な指示: ${personality.customInstructions}\n`;
+    }
+  }
+
+  // Product catalog
+  if (products.length > 0) {
+    systemPrompt += `\n## 取り扱い商品
+以下の商品を取り扱っています。お客様の要望に合わせて適切な商品をおすすめしてください。
+
+`;
+    products.forEach((product, index) => {
+      systemPrompt += `### ${index + 1}. ${product.name}
+`;
+      if (product.price) {
+        systemPrompt += `- 価格: ${product.currency} ${product.price}\n`;
+      }
+      if (product.description) {
+        systemPrompt += `- 説明: ${product.description}\n`;
+      }
+      if (product.category) {
+        systemPrompt += `- カテゴリ: ${product.category}\n`;
+      }
+      if (product.features && product.features.length > 0) {
+        systemPrompt += `- 特徴: ${product.features.join(", ")}\n`;
+      }
+      if (product.productUrl) {
+        systemPrompt += `- 商品ページ: ${product.productUrl}\n`;
+      }
+      systemPrompt += "\n";
+    });
+  }
+
+  // Knowledge base context
+  if (knowledgeBase.length > 0) {
+    systemPrompt += `\n## ナレッジベース
+以下の情報を参考にして回答してください。
+
+`;
+    knowledgeBase.forEach((kb) => {
+      if (kb.status === "READY") {
+        systemPrompt += `### ${kb.title}
+${kb.content.substring(0, 2000)}${kb.content.length > 2000 ? "..." : ""}
+
+`;
+      }
+    });
+  }
+
+  // Response guidelines
+  systemPrompt += `## 回答のガイドライン
+1. お客様の質問に対して、的確で役立つ回答をしてください
+2. 商品をおすすめする際は、お客様のニーズを理解した上で提案してください
+3. 分からないことは正直に伝え、無理に回答しないでください
+4. 購入を強要せず、お客様のペースに合わせてください
+5. 回答は簡潔にまとめ、必要に応じて詳細を補足してください
+6. 商品をおすすめする際は、可能であれば商品ページへのリンクも案内してください
+
+## 禁止事項
+- 競合他社の悪口を言うこと
+- 虚偽の情報を提供すること
+- 個人情報を聞き出すこと
+- 政治的・宗教的な話題に関与すること
+`;
+
+  return systemPrompt;
+}
+
+/**
+ * Generate a default personality config
+ */
+export function getDefaultPersonality(): PersonalityConfig {
+  return {
+    tone: "friendly",
+    formalityLevel: 5,
+    emojiUsage: 3,
+    greetingMessage: "こんにちは！何かお探しですか？お気軽にご質問ください。",
+    farewellMessage:
+      "ご質問ありがとうございました！またいつでもお気軽にどうぞ。",
+  };
+}

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -1,0 +1,243 @@
+import * as cheerio from "cheerio";
+import { generateResponse } from "./claude";
+
+export interface ScrapedPage {
+  url: string;
+  title: string;
+  description: string;
+  content: string;
+  links: string[];
+  images: string[];
+  metadata: Record<string, string>;
+}
+
+export interface ExtractedProduct {
+  name: string;
+  price?: number;
+  currency?: string;
+  description?: string;
+  imageUrl?: string;
+  productUrl?: string;
+  category?: string;
+  features?: string[];
+}
+
+/**
+ * Fetch and parse HTML from a URL
+ */
+export async function fetchPage(url: string): Promise<ScrapedPage> {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (compatible; OmakaseBot/1.0; +https://omakase-ai-clone.com)",
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+
+  const html = await response.text();
+  const $ = cheerio.load(html);
+
+  // Remove script and style tags
+  $("script, style, noscript").remove();
+
+  // Extract metadata
+  const metadata: Record<string, string> = {};
+  $("meta").each((_, el) => {
+    const name = $(el).attr("name") || $(el).attr("property");
+    const content = $(el).attr("content");
+    if (name && content) {
+      metadata[name] = content;
+    }
+  });
+
+  // Extract links
+  const links: string[] = [];
+  $("a[href]").each((_, el) => {
+    const href = $(el).attr("href");
+    if (href && !href.startsWith("#") && !href.startsWith("javascript:")) {
+      try {
+        const absoluteUrl = new URL(href, url).toString();
+        links.push(absoluteUrl);
+      } catch {
+        // Invalid URL, skip
+      }
+    }
+  });
+
+  // Extract images
+  const images: string[] = [];
+  $("img[src]").each((_, el) => {
+    const src = $(el).attr("src");
+    if (src) {
+      try {
+        const absoluteUrl = new URL(src, url).toString();
+        images.push(absoluteUrl);
+      } catch {
+        // Invalid URL, skip
+      }
+    }
+  });
+
+  // Get page content
+  const title = $("title").text().trim() || metadata["og:title"] || "";
+  const description =
+    metadata["description"] || metadata["og:description"] || "";
+  const content = $("body").text().replace(/\s+/g, " ").trim().substring(0, 10000);
+
+  return {
+    url,
+    title,
+    description,
+    content,
+    links: [...new Set(links)],
+    images: [...new Set(images)],
+    metadata,
+  };
+}
+
+/**
+ * Extract product information from HTML using Claude AI
+ */
+export async function extractProducts(
+  page: ScrapedPage
+): Promise<ExtractedProduct[]> {
+  const prompt = `以下のウェブページの情報から、商品情報を抽出してJSON配列形式で返してください。
+
+URL: ${page.url}
+タイトル: ${page.title}
+説明: ${page.description}
+
+ページ内容:
+${page.content.substring(0, 5000)}
+
+以下の形式でJSON配列を返してください。商品が見つからない場合は空の配列 [] を返してください:
+[
+  {
+    "name": "商品名",
+    "price": 1000,
+    "currency": "JPY",
+    "description": "商品の説明",
+    "category": "カテゴリ",
+    "features": ["特徴1", "特徴2"]
+  }
+]
+
+JSONのみを返し、他の説明文は含めないでください。`;
+
+  const systemPrompt = `あなたはECサイトの商品情報を抽出する専門家です。
+ウェブページの内容から商品情報を正確に抽出し、構造化されたJSONデータとして返してください。
+必ず有効なJSON配列のみを返してください。`;
+
+  try {
+    const response = await generateResponse(prompt, systemPrompt, {
+      temperature: 0.1, // Low temperature for consistent extraction
+    });
+
+    // Parse JSON from response
+    const jsonMatch = response.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const products = JSON.parse(jsonMatch[0]) as ExtractedProduct[];
+      return products;
+    }
+    return [];
+  } catch (error) {
+    console.error("Failed to extract products:", error);
+    return [];
+  }
+}
+
+/**
+ * Extract FAQ and common questions from page content
+ */
+export async function extractFAQ(
+  page: ScrapedPage
+): Promise<Array<{ question: string; answer: string }>> {
+  const prompt = `以下のウェブページの情報から、よくある質問（FAQ）を抽出してJSON配列形式で返してください。
+
+URL: ${page.url}
+タイトル: ${page.title}
+
+ページ内容:
+${page.content.substring(0, 5000)}
+
+以下の形式でJSON配列を返してください。FAQが見つからない場合は空の配列 [] を返してください:
+[
+  {
+    "question": "質問",
+    "answer": "回答"
+  }
+]
+
+JSONのみを返し、他の説明文は含めないでください。`;
+
+  const systemPrompt = `あなたはウェブページからFAQ情報を抽出する専門家です。
+ページ内容からよくある質問と回答を抽出し、構造化されたJSONデータとして返してください。
+必ず有効なJSON配列のみを返してください。`;
+
+  try {
+    const response = await generateResponse(prompt, systemPrompt, {
+      temperature: 0.1,
+    });
+
+    const jsonMatch = response.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      return JSON.parse(jsonMatch[0]);
+    }
+    return [];
+  } catch (error) {
+    console.error("Failed to extract FAQ:", error);
+    return [];
+  }
+}
+
+/**
+ * Scrape multiple pages from a website
+ */
+export async function scrapeWebsite(
+  startUrl: string,
+  maxPages: number = 10
+): Promise<ScrapedPage[]> {
+  const visited = new Set<string>();
+  const toVisit = [startUrl];
+  const pages: ScrapedPage[] = [];
+  const baseUrl = new URL(startUrl);
+
+  while (toVisit.length > 0 && pages.length < maxPages) {
+    const url = toVisit.shift()!;
+
+    if (visited.has(url)) continue;
+    visited.add(url);
+
+    try {
+      const page = await fetchPage(url);
+      pages.push(page);
+
+      // Add internal links to queue
+      for (const link of page.links) {
+        try {
+          const linkUrl = new URL(link);
+          if (
+            linkUrl.hostname === baseUrl.hostname &&
+            !visited.has(link) &&
+            !toVisit.includes(link)
+          ) {
+            toVisit.push(link);
+          }
+        } catch {
+          // Invalid URL, skip
+        }
+      }
+
+      // Rate limiting
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } catch (error) {
+      console.error(`Failed to scrape ${url}:`, error);
+    }
+  }
+
+  return pages;
+}


### PR DESCRIPTION
## Summary
Phase 2のAI接客機能コア部分を実装しました。

### 実装内容
- **Claude APIクライアント**: ストリーミング対応のClaude API統合
- **システムプロンプト生成**: エージェント設定からプロンプトを動的生成
- **Webスクレイピング**: Cheerioベースのスクレイパー
- **商品情報AI抽出**: Claude AIによる商品情報構造化
- **チャットAPI**: Server-Sent Events対応のストリーミングチャット
- **エージェントAPI**: CRUD操作エンドポイント

### 新規ファイル
- `src/lib/claude.ts` - Claude APIクライアント
- `src/lib/prompt-generator.ts` - プロンプト生成
- `src/lib/scraper.ts` - Webスクレイピング
- `src/app/api/chat/route.ts` - チャットAPI
- `src/app/api/agents/route.ts` - エージェント管理API

### 解決したIssue
- #31: Webスクレイピングエンジン実装
- #32: 商品情報自動抽出AI
- #33: Claude API クライアント実装
- #34: チャットAPI エンドポイント実装
- #35: システムプロンプト生成エンジン

## Test plan
- [ ] `CLAUDE_API_KEY` 環境変数設定
- [ ] `npm run dev` で開発サーバー起動
- [ ] API動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)