### PR TITLE
feat(ui): Dashboard UI and Chat Widget (Phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
         "lucide-react": "^0.559.0",
         "next": "16.0.8",
@@ -3266,6 +3267,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "lucide-react": "^0.559.0",
     "next": "16.0.8",

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,0 +1,461 @@
+/**
+ * Omakase AI Chat Widget
+ * Embeddable chat widget for EC sites
+ */
+
+(function() {
+  'use strict';
+
+  const OmakaseWidget = {
+    config: {
+      agentId: null,
+      position: 'bottom-right',
+      theme: 'light',
+      primaryColor: '#6366f1',
+      welcomeMessage: 'こんにちは！何かお探しですか？',
+      apiBaseUrl: window.location.origin
+    },
+
+    isOpen: false,
+    messages: [],
+    container: null,
+    iframe: null,
+
+    init: function(options) {
+      if (!options.agentId) {
+        console.error('OmakaseWidget: agentId is required');
+        return;
+      }
+
+      this.config = { ...this.config, ...options };
+      this.createWidget();
+      this.attachEventListeners();
+    },
+
+    createWidget: function() {
+      // Create container
+      this.container = document.createElement('div');
+      this.container.id = 'omakase-widget-container';
+      this.container.innerHTML = this.getWidgetHTML();
+      document.body.appendChild(this.container);
+
+      // Add styles
+      const style = document.createElement('style');
+      style.textContent = this.getWidgetCSS();
+      document.head.appendChild(style);
+    },
+
+    getWidgetHTML: function() {
+      const { position, theme, primaryColor } = this.config;
+      const positionClass = position === 'bottom-left' ? 'omakase-left' : 'omakase-right';
+      const themeClass = theme === 'dark' ? 'omakase-dark' : 'omakase-light';
+
+      return `
+        <div class="omakase-widget ${positionClass} ${themeClass}">
+          <!-- Chat Window -->
+          <div class="omakase-chat-window" id="omakase-chat-window" style="display: none;">
+            <div class="omakase-header" style="background-color: ${primaryColor};">
+              <div class="omakase-header-info">
+                <div class="omakase-avatar">${this.config.agentName ? this.config.agentName.charAt(0) : 'A'}</div>
+                <div class="omakase-header-text">
+                  <div class="omakase-agent-name">${this.config.agentName || 'アシスタント'}</div>
+                  <div class="omakase-status">オンライン</div>
+                </div>
+              </div>
+              <button class="omakase-close-btn" id="omakase-close-btn">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+            <div class="omakase-messages" id="omakase-messages"></div>
+            <div class="omakase-input-area">
+              <input type="text" class="omakase-input" id="omakase-input" placeholder="メッセージを入力..." />
+              <button class="omakase-send-btn" id="omakase-send-btn" style="background-color: ${primaryColor};">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="22" y1="2" x2="11" y2="13"></line>
+                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Toggle Button -->
+          <button class="omakase-toggle-btn" id="omakase-toggle-btn" style="background-color: ${primaryColor};">
+            <svg id="omakase-icon-chat" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+            </svg>
+            <svg id="omakase-icon-close" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display: none;">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+      `;
+    },
+
+    getWidgetCSS: function() {
+      const { theme } = this.config;
+      const bgColor = theme === 'dark' ? '#1f2937' : '#ffffff';
+      const textColor = theme === 'dark' ? '#ffffff' : '#1f2937';
+      const borderColor = theme === 'dark' ? '#374151' : '#e5e7eb';
+      const messageBg = theme === 'dark' ? '#374151' : '#f3f4f6';
+
+      return `
+        .omakase-widget {
+          position: fixed;
+          z-index: 999999;
+          bottom: 20px;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        }
+        .omakase-right { right: 20px; }
+        .omakase-left { left: 20px; }
+
+        .omakase-chat-window {
+          width: 360px;
+          height: 500px;
+          background: ${bgColor};
+          border-radius: 16px;
+          box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+          border: 1px solid ${borderColor};
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+          margin-bottom: 16px;
+        }
+
+        .omakase-header {
+          padding: 16px;
+          color: white;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+        }
+
+        .omakase-header-info {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .omakase-avatar {
+          width: 36px;
+          height: 36px;
+          border-radius: 50%;
+          background: rgba(255, 255, 255, 0.2);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: 600;
+          font-size: 14px;
+        }
+
+        .omakase-agent-name {
+          font-weight: 600;
+          font-size: 14px;
+        }
+
+        .omakase-status {
+          font-size: 12px;
+          opacity: 0.8;
+        }
+
+        .omakase-close-btn {
+          background: none;
+          border: none;
+          color: white;
+          cursor: pointer;
+          padding: 4px;
+          border-radius: 4px;
+          transition: background 0.2s;
+        }
+
+        .omakase-close-btn:hover {
+          background: rgba(255, 255, 255, 0.2);
+        }
+
+        .omakase-messages {
+          flex: 1;
+          overflow-y: auto;
+          padding: 16px;
+          background: ${messageBg};
+        }
+
+        .omakase-message {
+          margin-bottom: 12px;
+          display: flex;
+        }
+
+        .omakase-message.user {
+          justify-content: flex-end;
+        }
+
+        .omakase-message-content {
+          max-width: 80%;
+          padding: 10px 14px;
+          border-radius: 16px;
+          font-size: 14px;
+          line-height: 1.5;
+        }
+
+        .omakase-message.assistant .omakase-message-content {
+          background: ${bgColor};
+          color: ${textColor};
+          border-bottom-left-radius: 4px;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+        }
+
+        .omakase-message.user .omakase-message-content {
+          color: white;
+          border-bottom-right-radius: 4px;
+        }
+
+        .omakase-input-area {
+          padding: 16px;
+          border-top: 1px solid ${borderColor};
+          display: flex;
+          gap: 8px;
+          background: ${bgColor};
+        }
+
+        .omakase-input {
+          flex: 1;
+          padding: 10px 14px;
+          border: 1px solid ${borderColor};
+          border-radius: 8px;
+          font-size: 14px;
+          outline: none;
+          background: ${bgColor};
+          color: ${textColor};
+        }
+
+        .omakase-input:focus {
+          border-color: #6366f1;
+          box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+        }
+
+        .omakase-send-btn {
+          width: 40px;
+          height: 40px;
+          border-radius: 8px;
+          border: none;
+          color: white;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          transition: opacity 0.2s;
+        }
+
+        .omakase-send-btn:hover {
+          opacity: 0.9;
+        }
+
+        .omakase-send-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .omakase-toggle-btn {
+          width: 56px;
+          height: 56px;
+          border-radius: 50%;
+          border: none;
+          color: white;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+          transition: transform 0.2s, box-shadow 0.2s;
+        }
+
+        .omakase-toggle-btn:hover {
+          transform: scale(1.05);
+          box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+        }
+
+        .omakase-typing {
+          display: flex;
+          gap: 4px;
+          padding: 12px 16px;
+        }
+
+        .omakase-typing-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          background: #9ca3af;
+          animation: omakase-bounce 1.4s infinite ease-in-out both;
+        }
+
+        .omakase-typing-dot:nth-child(1) { animation-delay: -0.32s; }
+        .omakase-typing-dot:nth-child(2) { animation-delay: -0.16s; }
+
+        @keyframes omakase-bounce {
+          0%, 80%, 100% { transform: scale(0); }
+          40% { transform: scale(1); }
+        }
+      `;
+    },
+
+    attachEventListeners: function() {
+      const toggleBtn = document.getElementById('omakase-toggle-btn');
+      const closeBtn = document.getElementById('omakase-close-btn');
+      const sendBtn = document.getElementById('omakase-send-btn');
+      const input = document.getElementById('omakase-input');
+
+      toggleBtn.addEventListener('click', () => this.toggle());
+      closeBtn.addEventListener('click', () => this.close());
+      sendBtn.addEventListener('click', () => this.sendMessage());
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          this.sendMessage();
+        }
+      });
+
+      // Show welcome message on first open
+      if (this.config.welcomeMessage) {
+        this.messages.push({
+          role: 'assistant',
+          content: this.config.welcomeMessage
+        });
+      }
+    },
+
+    toggle: function() {
+      this.isOpen ? this.close() : this.open();
+    },
+
+    open: function() {
+      this.isOpen = true;
+      document.getElementById('omakase-chat-window').style.display = 'flex';
+      document.getElementById('omakase-icon-chat').style.display = 'none';
+      document.getElementById('omakase-icon-close').style.display = 'block';
+      document.getElementById('omakase-input').focus();
+      this.renderMessages();
+    },
+
+    close: function() {
+      this.isOpen = false;
+      document.getElementById('omakase-chat-window').style.display = 'none';
+      document.getElementById('omakase-icon-chat').style.display = 'block';
+      document.getElementById('omakase-icon-close').style.display = 'none';
+    },
+
+    renderMessages: function() {
+      const container = document.getElementById('omakase-messages');
+      container.innerHTML = this.messages.map(msg => `
+        <div class="omakase-message ${msg.role}">
+          <div class="omakase-message-content" ${msg.role === 'user' ? `style="background-color: ${this.config.primaryColor};"` : ''}>
+            ${this.escapeHtml(msg.content)}
+          </div>
+        </div>
+      `).join('');
+      container.scrollTop = container.scrollHeight;
+    },
+
+    showTyping: function() {
+      const container = document.getElementById('omakase-messages');
+      const typingHtml = `
+        <div class="omakase-message assistant" id="omakase-typing">
+          <div class="omakase-message-content">
+            <div class="omakase-typing">
+              <div class="omakase-typing-dot"></div>
+              <div class="omakase-typing-dot"></div>
+              <div class="omakase-typing-dot"></div>
+            </div>
+          </div>
+        </div>
+      `;
+      container.insertAdjacentHTML('beforeend', typingHtml);
+      container.scrollTop = container.scrollHeight;
+    },
+
+    hideTyping: function() {
+      const typing = document.getElementById('omakase-typing');
+      if (typing) typing.remove();
+    },
+
+    async sendMessage() {
+      const input = document.getElementById('omakase-input');
+      const content = input.value.trim();
+      if (!content) return;
+
+      // Add user message
+      this.messages.push({ role: 'user', content });
+      input.value = '';
+      this.renderMessages();
+      this.showTyping();
+
+      try {
+        const response = await fetch(`${this.config.apiBaseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: this.config.agentId,
+            messages: this.messages.map(m => ({ role: m.role, content: m.content }))
+          })
+        });
+
+        if (!response.ok) throw new Error('Failed to send message');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let assistantContent = '';
+
+        this.hideTyping();
+        this.messages.push({ role: 'assistant', content: '' });
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              const data = line.slice(6);
+              if (data === '[DONE]') continue;
+
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed.content) {
+                  assistantContent += parsed.content;
+                  this.messages[this.messages.length - 1].content = assistantContent;
+                  this.renderMessages();
+                }
+              } catch {
+                if (data.trim()) {
+                  assistantContent += data;
+                  this.messages[this.messages.length - 1].content = assistantContent;
+                  this.renderMessages();
+                }
+              }
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Chat error:', error);
+        this.hideTyping();
+        this.messages.push({
+          role: 'assistant',
+          content: '申し訳ございません。エラーが発生しました。もう一度お試しください。'
+        });
+        this.renderMessages();
+      }
+    },
+
+    escapeHtml: function(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+  };
+
+  // Expose globally
+  window.OmakaseWidget = OmakaseWidget;
+})();

--- a/src/app/(dashboard)/dashboard/agents/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/agents/new/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, ArrowRight, Globe, Wand2, Code, Loader2, Check, Copy } from "lucide-react";
+
+type Step = "url" | "settings" | "embed";
+
+const toneOptions = [
+  { value: "formal", label: "丁寧", description: "敬語を使った丁寧な対応" },
+  { value: "friendly", label: "フレンドリー", description: "親しみやすい対応" },
+  { value: "professional", label: "専門的", description: "専門知識を活かした対応" },
+  { value: "casual", label: "カジュアル", description: "リラックスした対応" },
+];
+
+export default function NewAgentPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>("url");
+  const [isLoading, setIsLoading] = useState(false);
+  const [createdAgentId, setCreatedAgentId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Form state
+  const [url, setUrl] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tone, setTone] = useState("friendly");
+  const [welcomeMessage, setWelcomeMessage] = useState(
+    "こんにちは！何かお探しですか？"
+  );
+
+  const handleUrlSubmit = () => {
+    if (!url) return;
+
+    // Auto-generate name from URL
+    try {
+      const urlObj = new URL(url);
+      setName(urlObj.hostname.replace("www.", ""));
+    } catch {
+      setName(url);
+    }
+
+    setStep("settings");
+  };
+
+  const handleCreateAgent = async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          websiteUrl: url,
+          description,
+          personality: {
+            tone,
+            formalityLevel: tone === "formal" ? 8 : tone === "casual" ? 3 : 5,
+            emojiUsage: tone === "friendly" ? 5 : tone === "casual" ? 7 : 2,
+            greetingMessage: welcomeMessage,
+          },
+        }),
+      });
+
+      if (!response.ok) throw new Error("Failed to create agent");
+
+      const agent = await response.json();
+      setCreatedAgentId(agent.id);
+      setStep("embed");
+    } catch (error) {
+      console.error("Failed to create agent:", error);
+      alert("エージェントの作成に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const embedCode = `<script src="${process.env.NEXT_PUBLIC_APP_URL || "https://your-app.vercel.app"}/widget.js"></script>
+<script>
+  OmakaseWidget.init({
+    agentId: "${createdAgentId || "YOUR_AGENT_ID"}",
+    position: "bottom-right",
+    theme: "light"
+  });
+</script>`;
+
+  const copyEmbedCode = () => {
+    navigator.clipboard.writeText(embedCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Progress indicator */}
+      <div className="flex items-center justify-center gap-2 mb-8">
+        {["url", "settings", "embed"].map((s, i) => (
+          <div key={s} className="flex items-center">
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+                step === s
+                  ? "bg-primary text-primary-foreground"
+                  : s === "url" || (s === "settings" && step !== "url") || step === "embed"
+                  ? "bg-primary/20 text-primary"
+                  : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {i + 1}
+            </div>
+            {i < 2 && (
+              <div
+                className={`w-12 h-0.5 ${
+                  (s === "url" && step !== "url") ||
+                  (s === "settings" && step === "embed")
+                    ? "bg-primary"
+                    : "bg-muted"
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Step 1: URL Input */}
+      {step === "url" && (
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center mb-4">
+              <Globe className="h-6 w-6 text-primary" />
+            </div>
+            <CardTitle>サイトURLを入力</CardTitle>
+            <CardDescription>
+              AIがサイトを解析し、商品情報を自動で学習します
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              type="url"
+              placeholder="https://your-shop.com"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              className="text-lg h-12"
+            />
+            <Button
+              className="w-full h-12"
+              onClick={handleUrlSubmit}
+              disabled={!url}
+            >
+              サイトを解析する
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Step 2: Settings */}
+      {step === "settings" && (
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center mb-4">
+              <Wand2 className="h-6 w-6 text-primary" />
+            </div>
+            <CardTitle>エージェントを設定</CardTitle>
+            <CardDescription>
+              エージェントの名前と性格を設定しましょう
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">エージェント名</label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例: マイショップアシスタント"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">説明（オプション）</label>
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="このエージェントの役割を説明してください"
+                rows={3}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <label className="text-sm font-medium">口調</label>
+              <div className="grid grid-cols-2 gap-3">
+                {toneOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => setTone(option.value)}
+                    className={`p-4 rounded-lg border-2 text-left transition-colors ${
+                      tone === option.value
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-muted-foreground"
+                    }`}
+                  >
+                    <div className="font-medium">{option.label}</div>
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {option.description}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">ウェルカムメッセージ</label>
+              <Textarea
+                value={welcomeMessage}
+                onChange={(e) => setWelcomeMessage(e.target.value)}
+                placeholder="最初の挨拶メッセージ"
+                rows={2}
+              />
+            </div>
+
+            <div className="flex gap-3">
+              <Button variant="outline" onClick={() => setStep("url")}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                戻る
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={handleCreateAgent}
+                disabled={!name || isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    作成中...
+                  </>
+                ) : (
+                  <>
+                    エージェントを作成
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Step 3: Embed Code */}
+      {step === "embed" && (
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center mb-4">
+              <Check className="h-6 w-6 text-green-600" />
+            </div>
+            <CardTitle>エージェント作成完了！</CardTitle>
+            <CardDescription>
+              以下のコードをサイトに貼り付けてください
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="relative">
+              <pre className="bg-muted p-4 rounded-lg text-sm overflow-x-auto">
+                <code>{embedCode}</code>
+              </pre>
+              <Button
+                variant="outline"
+                size="sm"
+                className="absolute top-2 right-2"
+                onClick={copyEmbedCode}
+              >
+                {copied ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => router.push(`/dashboard/agents/${createdAgentId}`)}
+              >
+                エージェント詳細へ
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={() => router.push("/dashboard/agents")}
+              >
+                ダッシュボードへ
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/agents/page.tsx
+++ b/src/app/(dashboard)/dashboard/agents/page.tsx
@@ -1,0 +1,115 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Bot, Plus, MessageSquare, Package, ExternalLink } from "lucide-react";
+
+export default async function AgentsPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const agents = await prisma.agent.findMany({
+    where: { userId: session.user.id },
+    include: {
+      _count: {
+        select: { conversations: true, products: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">エージェント管理</h1>
+          <p className="text-muted-foreground">
+            AIエージェントの作成・管理を行います
+          </p>
+        </div>
+        <Link href="/dashboard/agents/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            新規作成
+          </Button>
+        </Link>
+      </div>
+
+      {/* Agent grid */}
+      {agents.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {agents.map((agent) => (
+            <Link key={agent.id} href={`/dashboard/agents/${agent.id}`}>
+              <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                        <Bot className="h-5 w-5 text-primary" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-lg">{agent.name}</CardTitle>
+                        <CardDescription className="flex items-center gap-1 mt-1">
+                          <ExternalLink className="h-3 w-3" />
+                          <span className="truncate max-w-[180px]">
+                            {agent.websiteUrl}
+                          </span>
+                        </CardDescription>
+                      </div>
+                    </div>
+                    <Badge variant={agent.isActive ? "success" : "secondary"}>
+                      {agent.isActive ? "稼働中" : "停止中"}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  {agent.description && (
+                    <p className="text-sm text-muted-foreground mb-4 line-clamp-2">
+                      {agent.description}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-1">
+                      <MessageSquare className="h-4 w-4" />
+                      <span>{agent._count.conversations} 会話</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Package className="h-4 w-4" />
+                      <span>{agent._count.products} 商品</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <Bot className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-semibold mb-2">
+              エージェントがありません
+            </h3>
+            <p className="text-muted-foreground text-center mb-4 max-w-md">
+              URLを入力するだけで、AIがサイトを学習し、
+              自動で接客を始めます
+            </p>
+            <Link href="/dashboard/agents/new">
+              <Button size="lg">
+                <Plus className="mr-2 h-4 w-4" />
+                最初のエージェントを作成
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/conversations/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/conversations/[id]/page.tsx
@@ -1,0 +1,153 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ArrowLeft, Bot, User, Clock, Calendar } from "lucide-react";
+import { format, formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
+
+interface ConversationDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ConversationDetailPage({
+  params,
+}: ConversationDetailPageProps) {
+  const { id } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const conversation = await prisma.conversation.findUnique({
+    where: { id },
+    include: {
+      agent: {
+        select: { id: true, name: true, userId: true },
+      },
+      messages: {
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!conversation || conversation.agent.userId !== session.user.id) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link href="/dashboard/conversations">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold">
+              セッション: {conversation.sessionId?.slice(0, 8) || "匿名"}
+            </h1>
+            <Badge variant="outline">
+              <Bot className="h-3 w-3 mr-1" />
+              {conversation.agent.name}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground mt-1">
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3 w-3" />
+              {format(new Date(conversation.createdAt), "yyyy/MM/dd HH:mm", {
+                locale: ja,
+              })}
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {formatDistanceToNow(new Date(conversation.updatedAt), {
+                addSuffix: true,
+                locale: ja,
+              })}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">会話内容</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {conversation.messages.map((message) => (
+            <div
+              key={message.id}
+              className={`flex gap-3 ${
+                message.role === "USER" ? "flex-row-reverse" : ""
+              }`}
+            >
+              <Avatar className="h-8 w-8 flex-shrink-0">
+                <AvatarFallback
+                  className={
+                    message.role === "USER"
+                      ? "bg-blue-100 text-blue-600"
+                      : "bg-primary/10 text-primary"
+                  }
+                >
+                  {message.role === "USER" ? (
+                    <User className="h-4 w-4" />
+                  ) : (
+                    <Bot className="h-4 w-4" />
+                  )}
+                </AvatarFallback>
+              </Avatar>
+
+              <div
+                className={`flex flex-col max-w-[70%] ${
+                  message.role === "USER" ? "items-end" : "items-start"
+                }`}
+              >
+                <div
+                  className={`rounded-2xl px-4 py-2 ${
+                    message.role === "USER"
+                      ? "bg-primary text-primary-foreground rounded-br-md"
+                      : "bg-muted rounded-bl-md"
+                  }`}
+                >
+                  <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+                </div>
+                <span className="text-xs text-muted-foreground mt-1">
+                  {format(new Date(message.createdAt), "HH:mm", { locale: ja })}
+                </span>
+              </div>
+            </div>
+          ))}
+
+          {conversation.messages.length === 0 && (
+            <p className="text-center text-muted-foreground py-8">
+              メッセージがありません
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Metadata */}
+      {conversation.metadata && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">メタデータ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <pre className="text-xs bg-muted p-4 rounded-lg overflow-x-auto">
+              {JSON.stringify(conversation.metadata, null, 2)}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/conversations/page.tsx
+++ b/src/app/(dashboard)/dashboard/conversations/page.tsx
@@ -1,0 +1,117 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { MessageSquare, Clock, Bot, ChevronRight } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
+
+export default async function ConversationsPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const conversations = await prisma.conversation.findMany({
+    where: { agent: { userId: session.user.id } },
+    include: {
+      agent: {
+        select: { id: true, name: true },
+      },
+      messages: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+      _count: {
+        select: { messages: true },
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">会話履歴</h1>
+        <p className="text-muted-foreground">
+          顧客とのすべての会話を確認できます
+        </p>
+      </div>
+
+      {/* Conversation list */}
+      {conversations.length > 0 ? (
+        <div className="space-y-3">
+          {conversations.map((conversation) => {
+            const lastMessage = conversation.messages[0];
+            return (
+              <Link
+                key={conversation.id}
+                href={`/dashboard/conversations/${conversation.id}`}
+              >
+                <Card className="hover:shadow-md transition-shadow cursor-pointer">
+                  <CardContent className="p-4">
+                    <div className="flex items-start gap-4">
+                      <Avatar className="h-10 w-10">
+                        <AvatarFallback className="bg-primary/10 text-primary">
+                          {conversation.sessionId?.charAt(0) || "V"}
+                        </AvatarFallback>
+                      </Avatar>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium truncate">
+                              セッション: {conversation.sessionId?.slice(0, 8) || "匿名"}
+                            </span>
+                            <Badge variant="outline" className="text-xs">
+                              <Bot className="h-3 w-3 mr-1" />
+                              {conversation.agent.name}
+                            </Badge>
+                          </div>
+                          <div className="flex items-center text-xs text-muted-foreground">
+                            <Clock className="h-3 w-3 mr-1" />
+                            {formatDistanceToNow(
+                              new Date(conversation.updatedAt),
+                              { addSuffix: true, locale: ja }
+                            )}
+                          </div>
+                        </div>
+
+                        <p className="text-sm text-muted-foreground mt-1 truncate">
+                          {lastMessage?.content || "メッセージなし"}
+                        </p>
+
+                        <div className="flex items-center justify-between mt-2">
+                          <div className="flex items-center text-xs text-muted-foreground">
+                            <MessageSquare className="h-3 w-3 mr-1" />
+                            {conversation._count.messages} メッセージ
+                          </div>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <MessageSquare className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-semibold mb-2">会話がありません</h3>
+            <p className="text-muted-foreground text-center max-w-md">
+              AIエージェントが顧客と会話すると、ここに履歴が表示されます
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,115 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Bot, MessageSquare, Users, TrendingUp } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default async function DashboardPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  // Fetch user stats
+  const [agents, conversations, totalMessages] = await Promise.all([
+    prisma.agent.count({ where: { userId: session.user.id } }),
+    prisma.conversation.count({
+      where: { agent: { userId: session.user.id } },
+    }),
+    prisma.message.count({
+      where: { conversation: { agent: { userId: session.user.id } } },
+    }),
+  ]);
+
+  const stats = [
+    {
+      name: "エージェント数",
+      value: agents,
+      icon: Bot,
+      href: "/dashboard/agents",
+    },
+    {
+      name: "総会話数",
+      value: conversations,
+      icon: MessageSquare,
+      href: "/dashboard/conversations",
+    },
+    {
+      name: "総メッセージ数",
+      value: totalMessages,
+      icon: Users,
+      href: "/dashboard/analytics",
+    },
+    {
+      name: "コンバージョン",
+      value: "-",
+      icon: TrendingUp,
+      href: "/dashboard/analytics",
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      {/* Welcome header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">
+            こんにちは、{session.user.name || "ユーザー"}さん
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            今日もAIエージェントがあなたの代わりに接客中です
+          </p>
+        </div>
+        <Link href="/dashboard/agents/new">
+          <Button>
+            <Bot className="mr-2 h-4 w-4" />
+            新規エージェント作成
+          </Button>
+        </Link>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <Link key={stat.name} href={stat.href}>
+            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  {stat.name}
+                </CardTitle>
+                <stat.icon className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stat.value}</div>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+
+      {/* Quick actions */}
+      {agents === 0 && (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <Bot className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-semibold mb-2">
+              まだエージェントがありません
+            </h3>
+            <p className="text-muted-foreground text-center mb-4 max-w-md">
+              あなたのECサイトのURLを入力するだけで、
+              AIが自動で商品情報を学習し、接客を始めます
+            </p>
+            <Link href="/dashboard/agents/new">
+              <Button size="lg">
+                最初のエージェントを作成
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { Sidebar } from "@/components/dashboard/sidebar";
+import { Header } from "@/components/dashboard/header";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SessionProvider>
+      <div className="flex h-screen bg-background">
+        {/* Sidebar - hidden on mobile */}
+        <div className="hidden md:flex">
+          <Sidebar />
+        </div>
+
+        {/* Main content */}
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <Header />
+          <main className="flex-1 overflow-y-auto p-6">{children}</main>
+        </div>
+      </div>
+    </SessionProvider>
+  );
+}

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Bell, Menu } from "lucide-react";
+
+interface HeaderProps {
+  onMenuClick?: () => void;
+}
+
+export function Header({ onMenuClick }: HeaderProps) {
+  const { data: session } = useSession();
+
+  return (
+    <header className="flex h-16 items-center justify-between border-b bg-card px-6">
+      <div className="flex items-center gap-4">
+        {/* Mobile menu button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="md:hidden"
+          onClick={onMenuClick}
+        >
+          <Menu className="h-5 w-5" />
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-4">
+        {/* Notifications */}
+        <Button variant="ghost" size="icon">
+          <Bell className="h-5 w-5" />
+        </Button>
+
+        {/* User avatar */}
+        <div className="flex items-center gap-3">
+          <div className="hidden sm:block text-right">
+            <p className="text-sm font-medium">{session?.user?.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {session?.user?.email}
+            </p>
+          </div>
+          <Avatar>
+            <AvatarImage src={session?.user?.image || undefined} />
+            <AvatarFallback>
+              {session?.user?.name?.charAt(0) || "U"}
+            </AvatarFallback>
+          </Avatar>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  Bot,
+  LayoutDashboard,
+  MessageSquare,
+  BarChart3,
+  Settings,
+  CreditCard,
+  LogOut,
+} from "lucide-react";
+import { signOut } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+
+const navigation = [
+  { name: "ダッシュボード", href: "/dashboard", icon: LayoutDashboard },
+  { name: "エージェント", href: "/dashboard/agents", icon: Bot },
+  { name: "会話履歴", href: "/dashboard/conversations", icon: MessageSquare },
+  { name: "分析", href: "/dashboard/analytics", icon: BarChart3 },
+  { name: "プラン・請求", href: "/dashboard/billing", icon: CreditCard },
+  { name: "設定", href: "/dashboard/settings", icon: Settings },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex h-full w-64 flex-col bg-card border-r">
+      {/* Logo */}
+      <div className="flex h-16 items-center gap-2 px-6 border-b">
+        <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
+          <Bot className="h-5 w-5 text-primary-foreground" />
+        </div>
+        <span className="font-semibold text-lg">Omakase AI</span>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 space-y-1 px-3 py-4">
+        {navigation.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== "/dashboard" && pathname.startsWith(item.href));
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.name}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* User section */}
+      <div className="border-t p-4">
+        <Button
+          variant="ghost"
+          className="w-full justify-start gap-2 text-muted-foreground"
+          onClick={() => signOut({ callbackUrl: "/login" })}
+        >
+          <LogOut className="h-4 w-4" />
+          ログアウト
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/widget/chat-widget.tsx
+++ b/src/components/widget/chat-widget.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { MessageSquare, X, Send, Loader2, Minimize2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+}
+
+interface ChatWidgetProps {
+  agentId: string;
+  agentName?: string;
+  welcomeMessage?: string;
+  position?: "bottom-right" | "bottom-left";
+  theme?: "light" | "dark";
+  primaryColor?: string;
+}
+
+export function ChatWidget({
+  agentId,
+  agentName = "アシスタント",
+  welcomeMessage = "こんにちは！何かお探しですか？",
+  position = "bottom-right",
+  theme = "light",
+  primaryColor = "#6366f1",
+}: ChatWidgetProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Initialize with welcome message
+  useEffect(() => {
+    if (messages.length === 0 && welcomeMessage) {
+      setMessages([
+        {
+          id: "welcome",
+          role: "assistant",
+          content: welcomeMessage,
+          timestamp: new Date(),
+        },
+      ]);
+    }
+  }, [welcomeMessage, messages.length]);
+
+  // Scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const sendMessage = async () => {
+    if (!input.trim() || isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId,
+          messages: [...messages, userMessage].map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        }),
+      });
+
+      if (!response.ok) throw new Error("Failed to send message");
+
+      // Handle streaming response
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: "",
+        timestamp: new Date(),
+      };
+
+      setMessages((prev) => [...prev, assistantMessage]);
+
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split("\n");
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6);
+              if (data === "[DONE]") continue;
+
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed.content) {
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.id === assistantMessage.id
+                        ? { ...m, content: m.content + parsed.content }
+                        : m
+                    )
+                  );
+                }
+              } catch {
+                // Non-JSON data, might be plain text
+                if (data.trim()) {
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.id === assistantMessage.id
+                        ? { ...m, content: m.content + data }
+                        : m
+                    )
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Chat error:", error);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: "assistant",
+          content: "申し訳ございません。エラーが発生しました。もう一度お試しください。",
+          timestamp: new Date(),
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const positionClasses = {
+    "bottom-right": "right-4 bottom-4",
+    "bottom-left": "left-4 bottom-4",
+  };
+
+  const themeClasses = {
+    light: "bg-white text-gray-900",
+    dark: "bg-gray-900 text-white",
+  };
+
+  return (
+    <div className={cn("fixed z-50", positionClasses[position])}>
+      {/* Chat Window */}
+      {isOpen && (
+        <div
+          className={cn(
+            "mb-4 w-[360px] rounded-2xl shadow-2xl border overflow-hidden flex flex-col",
+            themeClasses[theme],
+            theme === "light" ? "border-gray-200" : "border-gray-700"
+          )}
+          style={{ height: "500px" }}
+        >
+          {/* Header */}
+          <div
+            className="flex items-center justify-between px-4 py-3 text-white"
+            style={{ backgroundColor: primaryColor }}
+          >
+            <div className="flex items-center gap-3">
+              <Avatar className="h-8 w-8 bg-white/20">
+                <AvatarFallback className="bg-white/20 text-white text-sm">
+                  {agentName.charAt(0)}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <div className="font-medium text-sm">{agentName}</div>
+                <div className="text-xs text-white/80">オンライン</div>
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-white hover:bg-white/20"
+                onClick={() => setIsOpen(false)}
+              >
+                <Minimize2 className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-white hover:bg-white/20"
+                onClick={() => setIsOpen(false)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Messages */}
+          <div
+            className={cn(
+              "flex-1 overflow-y-auto p-4 space-y-4",
+              theme === "light" ? "bg-gray-50" : "bg-gray-800"
+            )}
+          >
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={cn(
+                  "flex",
+                  message.role === "user" ? "justify-end" : "justify-start"
+                )}
+              >
+                <div
+                  className={cn(
+                    "max-w-[80%] rounded-2xl px-4 py-2 text-sm",
+                    message.role === "user"
+                      ? "bg-primary text-white rounded-br-md"
+                      : theme === "light"
+                      ? "bg-white text-gray-900 shadow-sm rounded-bl-md"
+                      : "bg-gray-700 text-white rounded-bl-md"
+                  )}
+                  style={
+                    message.role === "user"
+                      ? { backgroundColor: primaryColor }
+                      : undefined
+                  }
+                >
+                  {message.content}
+                </div>
+              </div>
+            ))}
+            {isLoading && (
+              <div className="flex justify-start">
+                <div
+                  className={cn(
+                    "rounded-2xl px-4 py-2 rounded-bl-md",
+                    theme === "light"
+                      ? "bg-white shadow-sm"
+                      : "bg-gray-700"
+                  )}
+                >
+                  <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Input */}
+          <div
+            className={cn(
+              "p-4 border-t",
+              theme === "light" ? "border-gray-200 bg-white" : "border-gray-700 bg-gray-900"
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="メッセージを入力..."
+                className={cn(
+                  "flex-1",
+                  theme === "dark" && "bg-gray-800 border-gray-700"
+                )}
+                disabled={isLoading}
+              />
+              <Button
+                size="icon"
+                onClick={sendMessage}
+                disabled={!input.trim() || isLoading}
+                style={{ backgroundColor: primaryColor }}
+              >
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toggle Button */}
+      <Button
+        size="icon"
+        className="h-14 w-14 rounded-full shadow-lg"
+        style={{ backgroundColor: primaryColor }}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {isOpen ? (
+          <X className="h-6 w-6" />
+        ) : (
+          <MessageSquare className="h-6 w-6" />
+        )}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ダッシュボードレイアウト（サイドバーナビゲーション、ヘッダー）を実装
- エージェント管理ページ（一覧、新規作成ウィザード）を作成
- 3ステップのエージェント作成フロー（URL入力 → 設定 → 埋め込みコード）
- ストリーミング対応の埋め込み可能なチャットウィジェットを構築
- 会話履歴ページ（一覧、詳細表示）を追加
- ライト/ダークテーマとカスタマイズ可能なカラーをサポート

## Files Changed
- `src/app/(dashboard)/` - ダッシュボードページ群
- `src/components/dashboard/` - サイドバー、ヘッダーコンポーネント
- `src/components/widget/` - Reactチャットウィジェット
- `public/widget.js` - 埋め込み用JavaScriptウィジェット

## Test Plan
- [ ] ダッシュボードページが正しく表示される
- [ ] サイドバーナビゲーションが機能する
- [ ] エージェント作成ウィザードが完了まで動作する
- [ ] チャットウィジェットが開閉できる
- [ ] 会話履歴が表示される

Closes #40, #42, #43, #44, #45, #46, #47, #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)